### PR TITLE
Update splitAtDelimiters

### DIFF
--- a/src/Latex.test.tsx
+++ b/src/Latex.test.tsx
@@ -35,4 +35,9 @@ describe('Latex', () => {
     const brokenRender = () => shallow(<Latex strict>{latex}</Latex>);
     expect(brokenRender).toThrowError();
   });
+
+  it("renders correctly sequences of $..$", () => {
+    const latex = "$hello$$world$$boo$";
+    const wrapper = shallow(<Latex>{latex}</Latex>);
+    expect(wrapper).toMatchSnapshot();
 });

--- a/src/__snapshots__/Latex.test.tsx.snap
+++ b/src/__snapshots__/Latex.test.tsx.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Latex renders correctly sequences of $..$ 1`] = `
+<span
+  className="__Latex__"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "<span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mi>h</mi><mi>e</mi><mi>l</mi><mi>l</mi><mi>o</mi></mrow><annotation encoding=\\"application/x-tex\\">hello</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.69444em;vertical-align:0em;\\"></span><span class=\\"mord mathnormal\\">h</span><span class=\\"mord mathnormal\\">e</span><span class=\\"mord mathnormal\\" style=\\"margin-right:0.01968em;\\">ll</span><span class=\\"mord mathnormal\\">o</span></span></span></span><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mi>w</mi><mi>o</mi><mi>r</mi><mi>l</mi><mi>d</mi></mrow><annotation encoding=\\"application/x-tex\\">world</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.69444em;vertical-align:0em;\\"></span><span class=\\"mord mathnormal\\" style=\\"margin-right:0.02691em;\\">w</span><span class=\\"mord mathnormal\\" style=\\"margin-right:0.02778em;\\">or</span><span class=\\"mord mathnormal\\" style=\\"margin-right:0.01968em;\\">l</span><span class=\\"mord mathnormal\\">d</span></span></span></span><span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mi>b</mi><mi>o</mi><mi>o</mi></mrow><annotation encoding=\\"application/x-tex\\">boo</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.69444em;vertical-align:0em;\\"></span><span class=\\"mord mathnormal\\">b</span><span class=\\"mord mathnormal\\">oo</span></span></span></span>",
+    }
+  }
+/>
+`;
+
 exports[`Latex renders raw LaTeX incase of error by default 1`] = `
 <span
   className="__Latex__"

--- a/src/renderLatex.ts
+++ b/src/renderLatex.ts
@@ -1,23 +1,12 @@
 /** Adapted from /contrib/auto-render/auto-render.js at github.com/Khan/KaTeX */
 
 import { renderToString  } from 'katex';
-import { KatexData, Delimiter } from './types';
+import { Delimiter } from './types';
 import splitAtDelimiters from './splitAtDelimiters';
 
 
-function splitWithDelimiters(text: string, delimiters: Delimiter[]): KatexData[] {
-  let data = [{ type: 'text', data: text }];
-  for (let i = 0; i < delimiters.length; i++) {
-    const delimiter = delimiters[i];
-    data = splitAtDelimiters(
-      data, delimiter.left, delimiter.right,
-      delimiter.display || false);
-  }
-  return data;
-};
-
 export default function renderLatexInTextAsHTMLString(text: string, delimiters: Delimiter[], strict: boolean): string {
-  const data = splitWithDelimiters(text, delimiters);
+  const data = splitAtDelimiters(text, delimiters);
   const fragments = []
 
   for (let i = 0; i < data.length; i++) {


### PR DESCRIPTION
Fixes #28.

I synced with https://github.com/KaTeX/KaTeX/tree/master/contrib/auto-render and fixed things TypeScript didn't like.