### PR TITLE
Add support for multiple children

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ import Latex from 'react-latex-next';
 
 function Example() {
   return (
-    <Latex>We give illustrations for the three processes $e^+e^-$, gluon-gluon and $\\gamma\\gamma \\to W t\\bar b$.</Latex>
+    <Latex>We give illustrations for the {1 + 2} processes $e^+e^-$, gluon-gluon and $\\gamma\\gamma \\to W t\\bar b$.</Latex>
   );
 }
 ```
 
-**Note**: `katex` CSS needs to be included in your final bundle. Above example is using `import` to load `css` but depending on how the code & styles are built and bundled, it may be different for your case. 
+**Note**: `katex` CSS needs to be included in your final bundle. Above example is using `import` to load `css` but depending on how the code & styles are built and bundled, it may be different for your case.
 
 ### delimiters
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -14,6 +14,10 @@ export default function App() {
   const [text, setText] = useState(INITIAL_TEXT_WITH_LATEX);
   const [strict, setStrict] = useState(INITIAL_STRICT_FLAG);
   const [macros, setMacros] = useState(INITIAL_MACROS);
+
+  const variableName = "variableOne";
+  const otherVariableName = "variableTwo";
+
   return (
     <main style={{ padding: 12, maxWidth: 780 }}>
       <h1>
@@ -73,6 +77,11 @@ export default function App() {
         <Latex strict={strict} macros={macros}>
           {text}
         </Latex>
+      </div>
+      <div>
+        <h2>Other examples</h2>
+        <Latex>${variableName} \times {otherVariableName}$</Latex>
+        <Latex>$3^9 = {Math.pow(3,9)}$</Latex>
       </div>
     </main>
   );

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -79,8 +79,16 @@ export default function App() {
         </Latex>
       </div>
       <div>
-        <h2>Other examples</h2>
+        <h2>Examples using JS expressions in LaTeX formula</h2>
+
+        <p>
+          <code>{`<Latex>\${variableName} \\times {otherVariableName}$</Latex>`}</code>
+        </p>
         <Latex>${variableName} \times {otherVariableName}$</Latex>
+
+        <p>
+          <code>{`<Latex>$3^9 = {Math.pow(3,9)}$</Latex>`}</code>
+        </p>
         <Latex>$3^9 = {Math.pow(3,9)}$</Latex>
       </div>
     </main>

--- a/src/Latex.test.tsx
+++ b/src/Latex.test.tsx
@@ -47,4 +47,10 @@ describe('Latex', () => {
     const wrapper = shallow(<Latex macros={{"\\R": "\\mathbb{R}"}}>{latex}</Latex>);
     expect(wrapper).toMatchSnapshot();
   })
+
+  it("handles multiple children inside the node", () => {
+    const latex = "$1 \\times 2$";
+    const wrapper = shallow(<Latex>Label: {latex}</Latex>);
+    expect(wrapper).toMatchSnapshot();
+  });
 })

--- a/src/Latex.tsx
+++ b/src/Latex.tsx
@@ -24,7 +24,7 @@ export default class Latex extends React.Component<LatexProps> {
 
   render() {
     const { children, delimiters, strict, macros } = this.props
-    const renderedLatex = renderLatex(Array.isArray(children) ? children.join() : children, delimiters!, strict!, macros);
+    const renderedLatex = renderLatex(Array.isArray(children) ? children.join('') : children, delimiters!, strict!, macros);
     return (
       <span className="__Latex__" dangerouslySetInnerHTML={{ __html: renderedLatex }} />
     )

--- a/src/Latex.tsx
+++ b/src/Latex.tsx
@@ -5,7 +5,7 @@ import { Delimiter } from './types';
 import './Latex.css'
 
 export interface LatexProps {
-  children: string;
+  children: string | string[];
   delimiters?: Delimiter[];
   strict?: boolean;
   macros?: Macros
@@ -24,7 +24,7 @@ export default class Latex extends React.Component<LatexProps> {
 
   render() {
     const { children, delimiters, strict, macros } = this.props
-    const renderedLatex = renderLatex(children, delimiters!, strict!, macros);
+    const renderedLatex = renderLatex(Array.isArray(children) ? children.join() : children, delimiters!, strict!, macros);
     return (
       <span className="__Latex__" dangerouslySetInnerHTML={{ __html: renderedLatex }} />
     )

--- a/src/__snapshots__/Latex.test.tsx.snap
+++ b/src/__snapshots__/Latex.test.tsx.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Latex handles multiple children inside the node 1`] = `
+<span
+  className="__Latex__"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "Label: <span class=\\"katex\\"><span class=\\"katex-mathml\\"><math xmlns=\\"http://www.w3.org/1998/Math/MathML\\"><semantics><mrow><mn>1</mn><mo>×</mo><mn>2</mn></mrow><annotation encoding=\\"application/x-tex\\">1 \\\\times 2</annotation></semantics></math></span><span class=\\"katex-html\\" aria-hidden=\\"true\\"><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.72777em;vertical-align:-0.08333em;\\"></span><span class=\\"mord\\">1</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span><span class=\\"mbin\\">×</span><span class=\\"mspace\\" style=\\"margin-right:0.2222222222222222em;\\"></span></span><span class=\\"base\\"><span class=\\"strut\\" style=\\"height:0.64444em;vertical-align:0em;\\"></span><span class=\\"mord\\">2</span></span></span></span>",
+    }
+  }
+/>
+`;
+
 exports[`Latex renders an expression with macros 1`] = `
 <span
   className="__Latex__"


### PR DESCRIPTION
Previously this library assumed that children was always a single text node, which mean that the following did not work:

```jsx
<Latex>$1 + {2} + {1 + 2}$<Latex>
```

React treats this as 5 children: `$1 + `, `2`, ` + `, `1 + 2` - which evaluates to `3`, and `$`

By checking if children is an array, the Latex component now has support for React evaluation, leading to all sorts of possibilities: 

```jsx
<Latex>${variableName} \times {otherVariableName}$</Latex>
<Latex>$3^9 = {Math.pow(3,9))$</Latex>
```